### PR TITLE
API-Version is now configurable. Default is v6.

### DIFF
--- a/YahooQuotesApi/YahooQuotesBuilder.cs
+++ b/YahooQuotesApi/YahooQuotesBuilder.cs
@@ -6,6 +6,18 @@ namespace YahooQuotesApi;
 public sealed class YahooQuotesBuilder
 {
     internal IClock Clock { get; private set; } = SystemClock.Instance;
+
+    private const string ApiDefaultVersion = "v6";
+    private string ApiVersion = "";
+    internal string BaseUrl { get; private set; }
+    private string BaseUrlPattern = "https://query2.finance.yahoo.com/{0}/finance/quote?symbols=";
+
+    public YahooQuotesBuilder(string apiVersion = ApiDefaultVersion)
+    {
+        ApiVersion = apiVersion;
+        BaseUrl = string.Format(BaseUrlPattern, apiVersion);
+    }
+
     internal YahooQuotesBuilder WithClock(IClock clock) // for testing
     {
         Clock = clock;


### PR DESCRIPTION
Fix to configure the Yahoo-API version, because version 7 is currently not working, default is now Version 6. All Tests passed.