### PR TITLE
Crumb generation to fix #16 API stop working again: Exception "quoteResponse"  404 (Not Found)

### DIFF
--- a/YahooQuotesApi.Test/Tests/HistoryTests.cs
+++ b/YahooQuotesApi.Test/Tests/HistoryTests.cs
@@ -21,8 +21,6 @@ public class HistoryTests : TestBase
 
         var security = await yahooQuotes.GetAsync("IBM", Histories.PriceHistory) ?? throw new ArgumentNullException();
 
-        security = await yahooQuotes.GetAsync("IBM", Histories.PriceHistory) ?? throw new ArgumentNullException();
-
         Assert.NotEmpty(security.PriceHistory.Value);
     }
 

--- a/YahooQuotesApi/Crumb/YahooCrumb.cs
+++ b/YahooQuotesApi/Crumb/YahooCrumb.cs
@@ -1,0 +1,73 @@
+﻿using System.Net.Http;
+
+namespace YahooQuotesApi.Crumb;
+
+public class YahooCrumb
+{
+    private const string YahooFcUrl = "https://fc.yahoo.com/";
+    private const string YahooGetCrumbUrl = "https://query2.finance.yahoo.com/v1/test/getcrumb";
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    private readonly object _lock = new();
+    private (IEnumerable<string>, string) _storedCookieAndCrumb;
+    private (IEnumerable<string>, string) StoredCookieAndCrumb
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _storedCookieAndCrumb;
+            }
+        }
+        set
+        {
+            lock (_lock)
+            {
+                _storedCookieAndCrumb = value;
+            }
+        }
+    }
+
+    public YahooCrumb(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<(IEnumerable<string>, string)> GetCookieAndCrumb(CancellationToken ct)
+    {
+        // Get from cache
+        if (StoredCookieAndCrumb != default((IEnumerable<string>, string)))
+            return StoredCookieAndCrumb;
+
+        // Not in cache, request it from Yahoo
+#pragma warning disable CA2000 // Dispose objects before losing scope, HttpClientFactory takes care of managing HttpClient instances
+        HttpClient httpClient = _httpClientFactory.CreateClient();
+#pragma warning restore CA2000 
+
+        // FC
+        Uri fcUrl = new(YahooFcUrl);
+
+        using HttpResponseMessage fcResponse = await httpClient.GetAsync(fcUrl, ct).ConfigureAwait(false);
+
+        if (!fcResponse.Headers.TryGetValues("Set-Cookie", out var cookie))
+            throw new InvalidOperationException("Set-Cookie header was not present in the response from " + fcUrl);
+
+        // Crumb
+        Uri crumbUrl = new(YahooGetCrumbUrl);
+
+        httpClient.DefaultRequestHeaders.Add("cookie", cookie);
+
+        using HttpResponseMessage response = await httpClient.GetAsync(crumbUrl, ct).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        string crumb = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(crumb))
+            throw new HttpRequestException($"Could not generate crumb from {YahooGetCrumbUrl} for cookie {cookie.First(x => x.StartsWith("A3", StringComparison.OrdinalIgnoreCase))}");
+
+        StoredCookieAndCrumb = (cookie, crumb);
+
+        return StoredCookieAndCrumb;
+    }
+}

--- a/YahooQuotesApi/Snapshot/YahooSnapshot.cs
+++ b/YahooQuotesApi/Snapshot/YahooSnapshot.cs
@@ -1,8 +1,10 @@
-﻿using System.IO;
+﻿using System.Data;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using YahooQuotesApi.Crumb;
 
 namespace YahooQuotesApi;
 
@@ -11,12 +13,14 @@ public sealed class YahooSnapshot : IDisposable
     private readonly ILogger Logger;
     private readonly IHttpClientFactory HttpClientFactory;
     private readonly YahooQuotesBuilder YahooQuotesBuilder;
+    private readonly YahooCrumb YahooCrumbService;
     private readonly SerialProducerCache<Symbol, Security?> Cache;
 
-    public YahooSnapshot(IClock clock, ILogger logger, YahooQuotesBuilder builder, IHttpClientFactory factory)
+    public YahooSnapshot(IClock clock, ILogger logger, YahooQuotesBuilder builder, YahooCrumb crumbService, IHttpClientFactory factory)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
         YahooQuotesBuilder = builder;
+        YahooCrumbService = crumbService;
         Logger = logger;
         HttpClientFactory = factory;
         Cache = new SerialProducerCache<Symbol, Security?>(clock, builder.SnapshotCacheDuration, Producer);
@@ -30,19 +34,24 @@ public sealed class YahooSnapshot : IDisposable
 
         return await Cache.Get(symbols, ct).ConfigureAwait(false);
     }
+
     private async Task<Dictionary<Symbol, Security?>> Producer(Symbol[] symbols, CancellationToken ct)
     {
         Dictionary<Symbol, Security?> dict = symbols.ToDictionary(s => s, s => (Security?)null);
+
         if (!symbols.Any())
             return dict;
+
         IEnumerable<JsonElement> elements = await GetElements(symbols, ct).ConfigureAwait(false);
-      
+
         foreach (JsonElement element in elements)
         {
             Security security = new(element, Logger);
             Symbol symbol = security.Symbol;
+
             if (!dict.ContainsKey(symbol))
                 throw new InvalidOperationException(symbol.Name);
+
             dict[symbol] = security;
         }
 
@@ -51,8 +60,10 @@ public sealed class YahooSnapshot : IDisposable
 
     private async Task<IEnumerable<JsonElement>> GetElements(Symbol[] symbols, CancellationToken ct)
     {
+        var (cookieValue, crumb) = await YahooCrumbService.GetCookieAndCrumb(ct).ConfigureAwait(false);
+
         (Uri uri, List<JsonElement> elements)[] datas =
-            GetUris(YahooQuotesBuilder.BaseUrl, symbols)
+            GetUris(YahooQuotesBuilder.BaseUrl, symbols, crumb)
                 .Select(uri => (uri, elements: new List<JsonElement>()))
                 .ToArray();
 
@@ -63,26 +74,27 @@ public sealed class YahooSnapshot : IDisposable
         };
 
         await Parallel.ForEachAsync(datas, parallelOptions, async (data, ct) =>
-            data.elements.AddRange(await MakeRequest(data.uri, ct).ConfigureAwait(false))).ConfigureAwait(false);
+            data.elements.AddRange(await MakeRequest(data.uri, cookieValue, ct).ConfigureAwait(false))).ConfigureAwait(false);
 
         return datas.Select(x => x.elements).SelectMany(x => x);
     }
 
-    private IEnumerable<Uri> GetUris(string baseUrl, IEnumerable<Symbol> symbols)
+    private IEnumerable<Uri> GetUris(string baseUrl, IEnumerable<Symbol> symbols, string crumb)
     {
         return symbols
             .Select(symbol => WebUtility.UrlEncode(symbol.Name))
             .Chunk(100)
-            .Select(s => $"{baseUrl}{string.Join(",", s)}")
+            .Select(s => $"{baseUrl}{string.Join(",", s)}&crumb={crumb}")
             .Select(s => new Uri(s));
     }
 
-    private async Task<JsonElement[]> MakeRequest(Uri uri, CancellationToken ct)
+    private async Task<JsonElement[]> MakeRequest(Uri uri, IEnumerable<string> cookieValue, CancellationToken ct)
     {
         Logger.LogInformation("{Uri}", uri.ToString());
 
         HttpClient httpClient = HttpClientFactory.CreateClient("snapshot");
         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        httpClient.DefaultRequestHeaders.Add("Cookie", cookieValue);
 
         //Don't use GetFromJsonAsync() or GetStreamAsync() because it would throw an exception
         //and not allow reading a json error messages such as NotFound.
@@ -92,8 +104,10 @@ public sealed class YahooSnapshot : IDisposable
 
         if (!jsonDocument.RootElement.TryGetProperty("quoteResponse", out JsonElement quoteResponse))
             throw new InvalidDataException("quoteResponse");
+
         if (!quoteResponse.TryGetProperty("error", out JsonElement error))
             throw new InvalidDataException("error");
+
         if (error.ValueKind is not JsonValueKind.Null)
         {
             string errorMessage = error.ToString();
@@ -105,8 +119,10 @@ public sealed class YahooSnapshot : IDisposable
             }
             throw new InvalidDataException($"Error requesting YahooSnapshot: {errorMessage}");
         }
+
         if (!quoteResponse.TryGetProperty("result", out JsonElement result))
             throw new InvalidDataException("result");
+
         return result.EnumerateArray().ToArray();
     }
 

--- a/YahooQuotesApi/Utilities/Services.cs
+++ b/YahooQuotesApi/Utilities/Services.cs
@@ -5,6 +5,7 @@ using Polly.Retry;
 using Polly.Timeout;
 using System.Net;
 using System.Net.Http;
+using YahooQuotesApi.Crumb;
 
 namespace YahooQuotesApi;
 
@@ -77,6 +78,7 @@ internal sealed class Services
             .AddSingleton<YahooHistory>()
             .AddSingleton<HistoryBaseComposer>()
             .AddSingleton<YahooModules>()
+            .AddSingleton<YahooCrumb>()
 
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
     }
@@ -102,7 +104,7 @@ internal static partial class Xtensions
                 AllowAutoRedirect = false,
                 //MaxConnectionsPerServer: default is int.MaxValue; with HTTP/2, every request tends to reuse the same connection
                 //CookieContainer = new CookieContainer(),
-                UseCookies = false // manual cookie handling, if any
+                UseCookies = false
             });
     }
 }

--- a/YahooQuotesApi/YahooQuotesBuilder.cs
+++ b/YahooQuotesApi/YahooQuotesBuilder.cs
@@ -7,7 +7,7 @@ public sealed class YahooQuotesBuilder
 {
     internal IClock Clock { get; private set; } = SystemClock.Instance;
 
-    private const string ApiDefaultVersion = "v6";
+    private const string ApiDefaultVersion = "v7";
     private string ApiVersion = "";
     internal string BaseUrl { get; private set; }
     private string BaseUrlPattern = "https://query2.finance.yahoo.com/{0}/finance/quote?symbols=";


### PR DESCRIPTION
Referenced issue: #16 

Added `YahooCrumb` singleton service class to create cookie/crumb pairs, which are now needed when firing requests to `~/finance/quote` endpoint. Once it generates the cookie and crumb pairs it caches it internally. As far as I've seen, the cookie has a long expiration date (around 1 year).

The YahooCrumb singleton instance is injected in the constructor of the `YahooSnapshot` class to be used for URL construction and to set cookies for the **snapshot** http client.

No new unit tests have been added but all existing tests pass.

Also changed the API Default version to **V7**.