### PR TITLE
suggestion to add specific user agent to enable the lib to be used on Android

### DIFF
--- a/YahooQuotesApi/YahooQuotesBuilder.cs
+++ b/YahooQuotesApi/YahooQuotesBuilder.cs
@@ -5,7 +5,7 @@ namespace YahooQuotesApi;
 
 public sealed class YahooQuotesBuilder
 {
-    public YahooQuotesBuilder() {}
+    public YahooQuotesBuilder() { }
 
     internal IClock Clock { get; private set; } = SystemClock.Instance;
     internal YahooQuotesBuilder WithClock(IClock clock) // for testing
@@ -59,6 +59,13 @@ public sealed class YahooQuotesBuilder
     internal YahooQuotesBuilder WithNonAdjustedClose() // for testing
     {
         NonAdjustedClose = true;
+        return this;
+    }
+
+    internal string SpecificUserAgent { get; private set; } = string.Empty;
+    public YahooQuotesBuilder WithSpecificUserAgent(string specificUserAgent)
+    {
+        SpecificUserAgent = specificUserAgent;
         return this;
     }
 


### PR DESCRIPTION
I would like to suggest adding a specific user agent to enable the lib to be used on Android.

If I don't use a fake user agent, it takes one from Android and the answer to a request, via the lib, is "Forbidden" making a wrong format json exception.

If I allow to, like this PR, to set a specific User Agent string while creating the Builder, I am able to have answers from Yahoo.