### PR TITLE
adjust path separator for cross platform

### DIFF
--- a/YahooQuotesApi.Demo/MyApp.cs
+++ b/YahooQuotesApi.Demo/MyApp.cs
@@ -47,7 +47,7 @@ public class MyApp
 
     private List<Symbol> GetSymbols(int number)
     {
-        const string path = @"..\..\..\symbols.txt";
+        string path = $"..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}symbols.txt";
 
         List<string> lines = File
             .ReadAllLines(path)


### PR DESCRIPTION
Adjust path separator to make the sample work on unix platforms.
Another alternative would be just copying symbols.txt to the output path. Then it does not neet to go up the directory tree.